### PR TITLE
Improve tor --verify-config report

### DIFF
--- a/etc/sudoers.d/whonixcheck
+++ b/etc/sudoers.d/whonixcheck
@@ -10,8 +10,8 @@ user ALL=(whonixcheck) NOPASSWD: /bin/bash -x /usr/lib/whonixcheck/whonixcheck
 user ALL=(whonixcheck) NOPASSWD: /bin/bash -x /usr/lib/whonixcheck/whonixcheck *
 
 ## Required for whonixcheck running "tor --verify-config".
-whonixcheck ALL=(debian-tor) NOPASSWD: /usr/bin/tor --verify-config
-whonixcheck ALL=(debian-tor) NOPASSWD: /usr/sbin/tor --verify-config
+whonixcheck ALL=NOPASSWD: /usr/bin/tor --defaults-torrc /usr/share/tor/tor-service-defaults-torrc -f /etc/tor/torrc --RunAsDaemon 0 --verify-config
+whonixcheck ALL=NOPASSWD: /usr/sbin/tor --defaults-torrc /usr/share/tor/tor-service-defaults-torrc -f /etc/tor/torrc --RunAsDaemon 0 --verify-config
 
 whonixcheck ALL=NOPASSWD: /bin/systemctl --no-pager --no-block status onion-grater
 

--- a/usr/lib/whonixcheck/check_tor_config.bsh
+++ b/usr/lib/whonixcheck/check_tor_config.bsh
@@ -49,10 +49,10 @@ check_tor_config() {
 
 <p>(Tor exit code: $tor_verify_config_exit_code)</p>
 
-<p><u><b>Tor concise reports (below warns and errors must be fixed before you can use Tor):</b></u>:
+<p><u><b>Tor concise reports (below warns and errors must be fixed before you can use Tor)</b></u>:
 <br></br>$tor_verify_config_output_concise</p>
 
-<p><u>Tor full reports:</u>:
+<p><u>Tor full reports</u>:
 <br></br>$tor_verify_config_output</p>
 
 Try to look at this report yourself by running.

--- a/usr/lib/whonixcheck/check_tor_config.bsh
+++ b/usr/lib/whonixcheck/check_tor_config.bsh
@@ -28,8 +28,11 @@ check_tor_config_do() {
    ## (You configured a non-loopback address [...])
 
    ## This has a /etc/sudoers.d exception.
-   tor_verify_config_output="$(sudo --non-interactive -u debian-tor tor --verify-config 2>&1)" || { tor_verify_config_exit_code="$?" ; true; };
+   tor_verify_config_output="$(sudo --non-interactive /usr/bin/tor --defaults-torrc /usr/share/tor/tor-service-defaults-torrc -f /etc/tor/torrc --RunAsDaemon 0 --verify-config 2>&1)" || { tor_verify_config_exit_code="$?" ; true; };
    tor_verify_config_output="$(/usr/lib/msgcollector/br_add "$tor_verify_config_output")"
+
+   # concise report which only contains complains with [warn] or [err] tags
+   tor_verify_config_output_concise="$(grep -E -w -h -i '\[warn\]|\[err\]' <<<"$tor_verify_config_output" 2>&1)" || true
 
    return 0
 }
@@ -46,16 +49,17 @@ check_tor_config() {
 
 <p>(Tor exit code: $tor_verify_config_exit_code)</p>
 
-<p><u>Tor reports</u>:
-<br></br>$tor_verify_config_output</p>
+<p><u><b>Tor concise reports (below warns and errors must be fixed before you can use Tor):</b></u>:
+<br></br>$tor_verify_config_output_concise</p>
 
-<p><b>You have to fix this error, before you can use Tor.</b></p>
+<p><u>Tor full reports:</u>:
+<br></br>$tor_verify_config_output</p>
 
 Try to look at this report yourself by running.
 
 $start_menu_instructions_system_first_part Terminal
 
-<blockquote>sudo -u debian-tor tor --verify-config</blockquote>
+<blockquote>sudo --non-interactive /usr/bin/tor --defaults-torrc /usr/share/tor/tor-service-defaults-torrc -f /etc/tor/torrc --RunAsDaemon 0 --verify-config</blockquote>
 
 <p>To try to fix this, please open your Tor config file.
 


### PR DESCRIPTION
Whonix starts Tor using systemd with this command: `/usr/bin/tor --defaults-torrc /usr/share/tor/tor-service-defaults-torrc -f /etc/tor/torrc --RunAsDaemon 0` Therefore, it is important to verify if Tor can work under exactly those parameters.

Tor report may be huge, making users feel overwhlemed. Therefore, we introduce Tor concise report which only contains complains with [warn] or [err] tags.

This commit introduces a new bug that should be fixed:

```
/usr/lib/whonixcheck/cleanup.bsh: line 215: cd: ..: Permission denied
[ERROR] [whonixcheck] -------------------------------------------------------------------------------
-- whonixcheck script bug.
-- No panic. Nothing is broken. Just some rare condition has been hit.
-- Try again later. There is likely a solution for this problem.
-- Please see Whonix News, Whonix Blog and Whonix User Help Forum.
-- Please report this bug!
--
-- who_ami: user
-- identifier:
-- exit_code: 1
-- error_cause: error_handler signal ERR detected with BASH_COMMAND:
cd ..
--
-- Experts only:
-- bash -x whonixcheck --verbose
-- for verbose output. Clean the output and report to Whonix developers.
-------------------------------------------------------------------------
whonixcheck: Error detected. Cleaning up... Exiting...
whonixcheck: signal ERR received. Cleaning up... Exiting...
```