### PR TITLE
Use correct tor --verify command

### DIFF
--- a/etc/sudoers.d/whonixcheck
+++ b/etc/sudoers.d/whonixcheck
@@ -10,8 +10,7 @@ user ALL=(whonixcheck) NOPASSWD: /bin/bash -x /usr/lib/whonixcheck/whonixcheck
 user ALL=(whonixcheck) NOPASSWD: /bin/bash -x /usr/lib/whonixcheck/whonixcheck *
 
 ## Required for whonixcheck running "tor --verify-config".
-whonixcheck ALL=(debian-tor) NOPASSWD: /usr/bin/tor --verify-config
-whonixcheck ALL=(debian-tor) NOPASSWD: /usr/sbin/tor --verify-config
+whonixcheck ALL=NOPASSWD: /usr/bin/tor --defaults-torrc /usr/share/tor/tor-service-defaults-torrc -f /etc/tor/torrc --RunAsDaemon 0 --verify-config
 
 whonixcheck ALL=NOPASSWD: /bin/systemctl --no-pager --no-block status onion-grater
 

--- a/usr/lib/whonixcheck/check_tor_config.bsh
+++ b/usr/lib/whonixcheck/check_tor_config.bsh
@@ -28,7 +28,7 @@ check_tor_config_do() {
    ## (You configured a non-loopback address [...])
 
    ## This has a /etc/sudoers.d exception.
-   tor_verify_config_output="$(sudo --non-interactive -u debian-tor tor --verify-config 2>&1)" || { tor_verify_config_exit_code="$?" ; true; };
+   tor_verify_config_output="$(sudo --non-interactive /usr/bin/tor --defaults-torrc /usr/share/tor/tor-service-defaults-torrc -f /etc/tor/torrc --RunAsDaemon 0 --verify-config 2>&1)" || { tor_verify_config_exit_code="$?" ; true; };
    tor_verify_config_output="$(/usr/lib/msgcollector/br_add "$tor_verify_config_output")"
 
    ## concise report which only contains complains with [warn] or [err] tags


### PR DESCRIPTION
The reason for this change has been explained in http://phabricator.whonix.org/T787

`+whonixcheck ALL=NOPASSWD: /usr/bin/tor --defaults-torrc /usr/share/tor/tor-service-defaults-torrc -f etc/tor/torrc --RunAsDaemon 0 --verify-config`

means “whonixcheck (as a user) may only run Tor with the specified arguments as root user without password”.