### PR TITLE
Use sudo when checking files in /sys

### DIFF
--- a/etc/sudoers.d/whonixcheck
+++ b/etc/sudoers.d/whonixcheck
@@ -49,3 +49,4 @@ whonixcheck ALL=NOPASSWD: /bin/cat /sys/class/net/eth1/carrier
 
 ## required for check_pvclock if /sys is restricted to root
 whonixcheck ALL=NOPASSWD: /bin/cat /sys/devices/system/clocksource/clocksource0/current_clocksource
+whonixcheck ALL=NOPASSWD: /bin/cat /sys/devices/system/clocksource/clocksource0/available_clocksource

--- a/etc/sudoers.d/whonixcheck
+++ b/etc/sudoers.d/whonixcheck
@@ -42,3 +42,10 @@ whonixcheck ALL=NOPASSWD: /bin/systemctl --no-pager --no-block --failed list-uni
 
 ## required for check_tor_pid
 whonixcheck ALL=NOPASSWD: /usr/lib/whonixcheck/check_tor_pid
+
+## required for check_network_interfaces if /sys is restricted to root
+whonixcheck ALL=NOPASSWD: /bin/cat /sys/class/net/eth0/carrier
+whonixcheck ALL=NOPASSWD: /bin/cat /sys/class/net/eth1/carrier
+
+## required for check_pvclock if /sys is restricted to root
+whonixcheck ALL=NOPASSWD: /bin/cat /sys/devices/system/clocksource/clocksource0/current_clocksource

--- a/usr/lib/whonixcheck/check_network_interfaces.bsh
+++ b/usr/lib/whonixcheck/check_network_interfaces.bsh
@@ -13,13 +13,13 @@ check_network_interfaces() {
    local failed eth0_failed eth1_failed
 
    failed=false
-   if ! cat /sys/class/net/eth0/carrier &>/dev/null ; then
+   if ! sudo cat /sys/class/net/eth0/carrier &>/dev/null ; then
       eth0_failed=true
       failed=true
    fi
 
    if [ "$vm_lower_case_short" = "gateway" ]; then
-      if ! cat /sys/class/net/eth1/carrier &>/dev/null ; then
+      if ! sudo cat /sys/class/net/eth1/carrier &>/dev/null ; then
          eth1_failed=true
          failed=true
       fi
@@ -48,7 +48,7 @@ Try to manually start Whonix networking.
 Or reboot.<br />
 <br />
 Debugging information:<br />
-Command <code>cat /sys/class/net/eth0/carrier</code> failed.<br />
+Command <code>sudo cat /sys/class/net/eth0/carrier</code> failed.<br />
 <br />
 $if_you_know_what_you_are_doing_msg</p>"
       $output_x ${output_opts[@]} --messagex --typex "error" --message "$MSG"
@@ -64,7 +64,7 @@ $if_you_know_what_you_are_doing_msg</p>"
 $if_you_know_what_you_are_doing_msg
 
 Debugging information:
-Command <code>cat /sys/class/net/eth1/carrier</code> failed.</p>"
+Command <code>sudo cat /sys/class/net/eth1/carrier</code> failed.</p>"
       $output_x ${output_opts[@]} --messagex --typex "error" --message "$MSG"
       $output_cli ${output_opts[@]} --messagecli --typecli "error" --message "$MSG"
       EXIT_CODE="1"

--- a/usr/lib/whonixcheck/check_network_interfaces.bsh
+++ b/usr/lib/whonixcheck/check_network_interfaces.bsh
@@ -13,13 +13,13 @@ check_network_interfaces() {
    local failed eth0_failed eth1_failed
 
    failed=false
-   if ! sudo cat /sys/class/net/eth0/carrier &>/dev/null ; then
+   if ! sudo --non-interactive cat /sys/class/net/eth0/carrier &>/dev/null ; then
       eth0_failed=true
       failed=true
    fi
 
    if [ "$vm_lower_case_short" = "gateway" ]; then
-      if ! sudo cat /sys/class/net/eth1/carrier &>/dev/null ; then
+      if ! sudo --non-interactive cat /sys/class/net/eth1/carrier &>/dev/null ; then
          eth1_failed=true
          failed=true
       fi
@@ -48,7 +48,7 @@ Try to manually start Whonix networking.
 Or reboot.<br />
 <br />
 Debugging information:<br />
-Command <code>sudo cat /sys/class/net/eth0/carrier</code> failed.<br />
+Command <code>sudo --non-interactive cat /sys/class/net/eth0/carrier</code> failed.<br />
 <br />
 $if_you_know_what_you_are_doing_msg</p>"
       $output_x ${output_opts[@]} --messagex --typex "error" --message "$MSG"
@@ -64,7 +64,7 @@ $if_you_know_what_you_are_doing_msg</p>"
 $if_you_know_what_you_are_doing_msg
 
 Debugging information:
-Command <code>sudo cat /sys/class/net/eth1/carrier</code> failed.</p>"
+Command <code>sudo --non-interactive cat /sys/class/net/eth1/carrier</code> failed.</p>"
       $output_x ${output_opts[@]} --messagex --typex "error" --message "$MSG"
       $output_cli ${output_opts[@]} --messagecli --typecli "error" --message "$MSG"
       EXIT_CODE="1"

--- a/usr/lib/whonixcheck/check_pvclock.bsh
+++ b/usr/lib/whonixcheck/check_pvclock.bsh
@@ -53,8 +53,8 @@ This is non-ideal. A known issue. Contributions happily considered. Read more: <
    fi
 
    local current_clocksource available_clocksource
-   current_clocksource="$(sudo cat "/sys/devices/system/clocksource/clocksource0/current_clocksource")" || true
-   available_clocksource="$(sudo cat "/sys/devices/system/clocksource/clocksource0/available_clocksource")" || true
+   current_clocksource="$(sudo --non-interactive cat "/sys/devices/system/clocksource/clocksource0/current_clocksource")" || true
+   available_clocksource="$(sudo --non-interactive cat "/sys/devices/system/clocksource/clocksource0/available_clocksource")" || true
 
    if [ "$current_clocksource" = "xen" ]; then
       local MSG="<p>PVClock Result: <code>/sys/devices/system/clocksource/clocksource0/current_clocksource</code> exist, is <code>$current_clocksource</code>. \

--- a/usr/lib/whonixcheck/check_pvclock.bsh
+++ b/usr/lib/whonixcheck/check_pvclock.bsh
@@ -53,8 +53,8 @@ This is non-ideal. A known issue. Contributions happily considered. Read more: <
    fi
 
    local current_clocksource available_clocksource
-   current_clocksource="$(cat "/sys/devices/system/clocksource/clocksource0/current_clocksource")" || true
-   available_clocksource="$(cat "/sys/devices/system/clocksource/clocksource0/available_clocksource")" || true
+   current_clocksource="$(sudo cat "/sys/devices/system/clocksource/clocksource0/current_clocksource")" || true
+   available_clocksource="$(sudo cat "/sys/devices/system/clocksource/clocksource0/available_clocksource")" || true
 
    if [ "$current_clocksource" = "xen" ]; then
       local MSG="<p>PVClock Result: <code>/sys/devices/system/clocksource/clocksource0/current_clocksource</code> exist, is <code>$current_clocksource</code>. \


### PR DESCRIPTION
If /sys is restricted to root (https://github.com/Whonix/security-misc/pull/31) then whonixcheck will break as it needs some files in /sys so this adds sudoers exceptions so it can check those files.