### PR TITLE
Give access to /dev/pts/[0-9]*

### DIFF
--- a/etc/apparmor.d/usr.bin.whonixcheck
+++ b/etc/apparmor.d/usr.bin.whonixcheck
@@ -408,4 +408,6 @@
 	## Qubes specific
 	/run/qubes-whonix/ r,
 	/run/qubes-whonix/qubes.SetDateTime r,
+	
+	/dev/pts/[0-9]* rw,
 }


### PR DESCRIPTION
Otherwise, whonixcheck fails with an error when using a full system MAC policy.

```
## whonixcheck script bug. 
## No panic. Nothing is broken. Just some rare condition has been hit. 
## Try again later. There is likely a solution for this problem. 
## Please see Whonix News, Whonix Blog and Whonix User Help Forum. 
## Please report this bug! 
## 
## who_ami: whonixcheck 
## identifier: 
## exit_code: 0 
## error_cause: error_handler signal ERR detected with BASH_COMMAND: $output_tool --identifier "$IDENTIFIER" --whoami "$who_ami" "$@" 
## 
## Experts only: 
## bash -x whonixcheck --verbose 
## for verbose output. Clean the output and report to Whonix developers. 
```