### PR TITLE
Depends: replace bsdtar with libarchive-tools

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Package: whonixcheck
 Architecture: all
 Depends: anon-gw-base-files | anon-ws-base-files, dist-base-files, curl,
  ca-certificates, msgcollector, psmisc, sudo, vrms,
- bsdtar, helper-scripts, net-tools, systemd, adduser,
+ libarchive-tools, helper-scripts, net-tools, systemd, adduser,
  security-misc, spectre-meltdown-checker,
  apparmor-profile-dist, ${misc:Depends}
 Replaces: apparmor-profile-whonixcheck


### PR DESCRIPTION
`bsdtar` has been a transitional dummy package since `stretch`, and is removed completely as of `bullseye`.